### PR TITLE
Adding bcmath to list of required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/console": "^3.3",
     "psr/log": "^1.0",
     "php": ">=7.1",
-    "mouf/utils.log.psr.errorlog_logger": "^2.0"
+    "mouf/utils.log.psr.errorlog_logger": "^2.0",
+    "ext-bcmath": "*"
   },
   "require-dev" : {
     "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
bcmath is required for DBFaker to work.
But it is not installed on all computers. So it makes sense to declare it as a requirement.
This way, if bcmath is not installed, composer will let us know at install time.