### PR TITLE
Text max length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/console": "^3.3",
     "psr/log": "^1.0",
     "php": ">=7.1",
-    "mouf/utils.log.psr.errorlog_logger": "^2.0"
+    "mouf/utils.log.psr.errorlog_logger": "^2.0",
+    "ext-bcmath": "*"
   },
   "require-dev" : {
     "phpunit/phpunit": "^7.0",

--- a/src/Generators/TextGenerator.php
+++ b/src/Generators/TextGenerator.php
@@ -39,7 +39,8 @@ class TextGenerator implements FakeDataGeneratorInterface
     public function __invoke() : string
     {
         $colLength = $this->column->getLength();
-        $maxLength = $colLength > 5 ? max($colLength, 300) : $colLength;
+        $maxLength = min($colLength, 300);
+
         return $colLength > 5 ? $this->faker->text($maxLength) : substr($this->faker->text(5), 0, $colLength - 1);
     }
 


### PR DESCRIPTION
When running test suite with MySQL 5.7, got:

```

There was 1 error:

1) DBFaker\DBFakerTest::testFaker
Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'INSERT INTO users (id, parent_id, country_id, lastname, firstname, password, uuid, birth_date, access_level, last_access) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [260387143, 727428416, -765236960, "Voluptates maxime dolorem id vitae nesciunt quia asperiores aut. Error praesentium cum suscipit molestiae. Eum hic quod qui porro est omnis. Eos tenetur et nostrum sit.", "Id quis minus cum saepe dolorem et consequatur. Omnis vel eveniet sed nisi perspiciatis laborum. Perspiciatis quia fuga vel rerum illum id. Voluptatum quaerat voluptas hic aspernatur aut deserunt. Non rem laboriosam eos eaque praesentium. Nam ullam et eius sunt sint ad tempore molestiae.", "Laudantium excepturi ipsa ipsa eos. Perspiciatis omnis non neque. Adipisci quas nihil animi qui. Nobis est rerum sit eum. Molestiae eos adipisci rerum voluptates. Consequatur aut quisquam quia aut quaerat quia.", "0cce6cc8-fe10-3963-bfc3-2ff4806cb0c0", "2017-07-14", -10241, "1987-03-17 15:10:36"]:

SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'lastname' at row 1

/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:126
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:184
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:158
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1093
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
/home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147

Caused by
Doctrine\DBAL\Driver\PDOException: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'lastname' at row 1

/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:144
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1084
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
/home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147

Caused by
PDOException: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'lastname' at row 1

/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:142
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1084
/home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
/home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
/home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147

```

Tracked down the error to this line:

```php
$maxLength = $colLength > 5 ? max($colLength, 300) : $colLength;
```

I think the idea was that if maxlength for the column was 4GB, we generate at most 300 characters (otherwise that would be pretty long...)

But the code is actually making the length 300, even if column length is 10.

Fixed with:

```php
$maxLength = min($colLength, 300);
```
