### PR TITLE
Bigints can overflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/console": "^3.3",
     "psr/log": "^1.0",
     "php": ">=7.1",
-    "mouf/utils.log.psr.errorlog_logger": "^2.0"
+    "mouf/utils.log.psr.errorlog_logger": "^2.0",
+    "ext-bcmath": "*"
   },
   "require-dev" : {
     "phpunit/phpunit": "^7.0",

--- a/src/Generators/TextGenerator.php
+++ b/src/Generators/TextGenerator.php
@@ -39,7 +39,8 @@ class TextGenerator implements FakeDataGeneratorInterface
     public function __invoke() : string
     {
         $colLength = $this->column->getLength();
-        $maxLength = $colLength > 5 ? max($colLength, 300) : $colLength;
+        $maxLength = min($colLength, 300);
+
         return $colLength > 5 ? $this->faker->text($maxLength) : substr($this->faker->text(5), 0, $colLength - 1);
     }
 

--- a/src/Helpers/NumericColumnLimitHelper.php
+++ b/src/Helpers/NumericColumnLimitHelper.php
@@ -78,11 +78,11 @@ class NumericColumnLimitHelper
         $precisionValue = $this->getAbsValueByLengthPrecision($this->column);
         switch ($this->column->getType()->getName()){
             case Type::BIGINT:
-                return $this->column->getUnsigned() ? bcpow('2', '64') : bcsub(bcpow('2', '63') , '1');
+                return $this->column->getUnsigned() ? bcsub(bcpow('2', '64'), 1) : bcsub(bcpow('2', '63') , '1');
             case Type::INTEGER:
-                return $this->column->getUnsigned() ? bcpow('2', '32') : min($precisionValue, bcsub( bcpow('2', '31') , '1'));
+                return $this->column->getUnsigned() ? bcsub(bcpow('2', '32'), 1) : min($precisionValue, bcsub( bcpow('2', '31') , '1'));
             case Type::SMALLINT:
-                return $this->column->getUnsigned() ? bcpow('2', '16') : bcsub( bcpow('2', '15') , '1');
+                return $this->column->getUnsigned() ? bcsub(bcpow('2', '16'), 1) : bcsub( bcpow('2', '15') , '1');
             case Type::DECIMAL:
                 return $this->column->getUnsigned() ? 0 : $precisionValue;
             case Type::FLOAT:

--- a/src/Helpers/NumericColumnLimitHelper.php
+++ b/src/Helpers/NumericColumnLimitHelper.php
@@ -52,7 +52,7 @@ class NumericColumnLimitHelper
         $precisionValue = $this->getAbsValueByLengthPrecision($this->column);
         switch ($this->column->getType()->getName()){
             case Type::BIGINT:
-                return $this->column->getUnsigned() ? 0 : bcpow('2', '63');
+                return $this->column->getUnsigned() ? 0 : bcmul('-1', bcpow('2', '63'));
                 break;
             case Type::INTEGER:
                 return $this->column->getUnsigned() ? 0 : max(-1 * $precisionValue, bcmul('-1' , bcpow('2', '31')));


### PR DESCRIPTION
Tested unit tests with MySQL 5.7.

Got:

```
Doctrine\DBAL\Exception\DriverException : An exception occurred while executing 'INSERT INTO countries (id, president_id, name, population, birthrate, population_density, summary) VALUES (?, ?, ?, ?, ?, ?, ?)' with params [null, 173255025, "Culpa officia quis laudantium fugit est. Impedit vel debitis tempora accusamus quos et at.", "9223372036854775808", "\x49\x4e\x46", 0.082423135, "Fuga"]:

SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'population' at row 1
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:126
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:184
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:158
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1093
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
 /home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147
 
 Caused by
 Doctrine\DBAL\Driver\PDOException: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'population' at row 1
 
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:144
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1084
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
 /home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147
 
 Caused by
 PDOException: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'population' at row 1
 
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:142
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1084
 /home/david/projects/sandbox/DBFaker/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:805
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:244
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:194
 /home/david/projects/sandbox/DBFaker/src/DBFaker.php:120
 /home/david/projects/sandbox/DBFaker/tests/DBFakerTest.php:147
```

It seems this is related to an error in the minmum value of bigint integers (the minimum value was 2^31 instead of -2^31

